### PR TITLE
JBMAR-149 : Support for hook into the serialization process

### DIFF
--- a/api/src/main/java/org/jboss/marshalling/AbstractMarshaller.java
+++ b/api/src/main/java/org/jboss/marshalling/AbstractMarshaller.java
@@ -38,6 +38,8 @@ public abstract class AbstractMarshaller extends AbstractObjectOutput implements
     protected final ClassResolver classResolver;
     /** The configured object resolver. */
     protected final ObjectResolver objectResolver;
+    /** The configured pre object resolver. */
+    protected final ObjectResolver objectPreResolver;
     /** The configured class table. */
     protected final ClassTable classTable;
     /** The configured object table. */
@@ -65,6 +67,8 @@ public abstract class AbstractMarshaller extends AbstractObjectOutput implements
         this.classResolver = classResolver == null ? marshallerFactory.getDefaultClassResolver() : classResolver;
         final ObjectResolver objectResolver = configuration.getObjectResolver();
         this.objectResolver = objectResolver == null ? marshallerFactory.getDefaultObjectResolver() : objectResolver;
+        final ObjectResolver objectPreResolver = configuration.getObjectPreResolver();
+        this.objectPreResolver = objectPreResolver == null ? marshallerFactory.getDefaultObjectResolver() : objectPreResolver;
         final ClassTable classTable = configuration.getClassTable();
         this.classTable = classTable == null ? marshallerFactory.getDefaultClassTable() : classTable;
         final ObjectTable objectTable = configuration.getObjectTable();

--- a/api/src/main/java/org/jboss/marshalling/AbstractUnmarshaller.java
+++ b/api/src/main/java/org/jboss/marshalling/AbstractUnmarshaller.java
@@ -38,6 +38,8 @@ public abstract class AbstractUnmarshaller extends AbstractObjectInput implement
     protected final ClassResolver classResolver;
     /** The configured object resolver. */
     protected final ObjectResolver objectResolver;
+    /** The configured object pre resolver. */
+    protected final ObjectResolver objectPreResolver;
     /** The configured class table. */
     protected final ClassTable classTable;
     /** The configured object table. */
@@ -65,6 +67,8 @@ public abstract class AbstractUnmarshaller extends AbstractObjectInput implement
         this.classResolver = classResolver == null ? marshallerFactory.getDefaultClassResolver() : classResolver;
         final ObjectResolver objectResolver = configuration.getObjectResolver();
         this.objectResolver = objectResolver == null ? marshallerFactory.getDefaultObjectResolver() : objectResolver;
+        final ObjectResolver objectPreResolver = configuration.getObjectPreResolver();
+        this.objectPreResolver = objectPreResolver == null ? marshallerFactory.getDefaultObjectResolver() : objectPreResolver;
         final ClassTable classTable = configuration.getClassTable();
         this.classTable = classTable == null ? marshallerFactory.getDefaultClassTable() : classTable;
         final ObjectTable objectTable = configuration.getObjectTable();

--- a/api/src/main/java/org/jboss/marshalling/MarshallingConfiguration.java
+++ b/api/src/main/java/org/jboss/marshalling/MarshallingConfiguration.java
@@ -40,6 +40,7 @@ public final class MarshallingConfiguration implements Cloneable {
     private int classCount = 64;
     private int bufferSize = 512;
     private int version = -1;
+    private ObjectResolver objectPreResolver;
 
     /**
      * Construct a new instance.
@@ -119,6 +120,26 @@ public final class MarshallingConfiguration implements Cloneable {
         this.objectResolver = objectResolver;
     }
 
+    /**
+     * Get the object pre resolver, or {@code null} if none is specified.
+     *
+     * @return the object resolver
+     */
+    public ObjectResolver getObjectPreResolver() {
+        return objectPreResolver;
+    }
+
+    /**
+     * Set the object pre resolver, or {@code null} to use none.
+     * Invoked before user replacement and global object resolver
+     *
+     * @param objectResolver the object resolver
+     */
+    public void setObjectPreResolver(final ObjectResolver objectPreResolver) {
+        this.objectPreResolver = objectPreResolver;
+    }
+
+    
     /**
      * Get the class table, or {@code null} if none is specified.
      *

--- a/api/src/main/java/org/jboss/marshalling/cloner/ClonerConfiguration.java
+++ b/api/src/main/java/org/jboss/marshalling/cloner/ClonerConfiguration.java
@@ -32,6 +32,7 @@ public final class ClonerConfiguration implements Cloneable {
 
     private CloneTable cloneTable;
     private ObjectResolver objectResolver;
+    private ObjectResolver objectPreResolver;
     private ClassCloner classCloner;
     private SerializabilityChecker serializabilityChecker;
     private int bufferSize;
@@ -86,6 +87,25 @@ public final class ClonerConfiguration implements Cloneable {
      */
     public void setObjectResolver(final ObjectResolver objectResolver) {
         this.objectResolver = objectResolver;
+    }
+
+    /**
+     * Get the object pre resolver, or {@code null} if none is specified.
+     *
+     * @return the object resolver
+     */
+    public ObjectResolver getObjectPreResolver() {
+        return objectPreResolver;
+    }
+
+    /**
+     * Set the object pre resolver, or {@code null} to use none.
+     * Invoked before user replacement and global object resolver
+     *
+     * @param objectResolver the object resolver
+     */
+    public void setObjectPreResolver(final ObjectResolver objectPreResolver) {
+        this.objectPreResolver = objectPreResolver;
     }
 
     /**

--- a/api/src/main/java/org/jboss/marshalling/cloner/SerializingCloner.java
+++ b/api/src/main/java/org/jboss/marshalling/cloner/SerializingCloner.java
@@ -84,6 +84,7 @@ import org.jboss.marshalling.util.ShortReadField;
 class SerializingCloner implements ObjectCloner {
     private final CloneTable delegate;
     private final ObjectResolver objectResolver;
+    private final ObjectResolver objectPreResolver;
     private final ClassCloner classCloner;
     private final SerializabilityChecker serializabilityChecker;
     private final int bufferSize;
@@ -100,6 +101,8 @@ class SerializingCloner implements ObjectCloner {
         this.delegate = delegate == null ? CloneTable.NULL : delegate;
         final ObjectResolver objectResolver = configuration.getObjectResolver();
         this.objectResolver = objectResolver == null ? Marshalling.nullObjectResolver() : objectResolver;
+        final ObjectResolver objectPreResolver = configuration.getObjectPreResolver();
+        this.objectPreResolver = objectPreResolver == null ? Marshalling.nullObjectResolver() : objectPreResolver;
         final ClassCloner classCloner = configuration.getClassCloner();
         this.classCloner = classCloner == null ? ClassCloner.IDENTITY : classCloner;
         final SerializabilityChecker serializabilityChecker = configuration.getSerializabilityChecker();
@@ -142,21 +145,22 @@ class SerializingCloner implements ObjectCloner {
         if (cached != null) {
             return cached;
         }
+        Object replaced = orig;
+        replaced = objectPreResolver.writeReplace(replaced);
         final ClassCloner classCloner = this.classCloner;
-        if (orig instanceof Class) {
-            final Class<?> classObj = (Class<?>) orig;
+        if (replaced instanceof Class) {
+            final Class<?> classObj = (Class<?>) replaced;
             final Class<?> clonedClass = Proxy.isProxyClass(classObj) ? classCloner.cloneProxy(classObj) : classCloner.clone(classObj);
-            clones.put(orig, clonedClass);
+            clones.put(replaced, clonedClass);
             return clonedClass;
         }
-        if ((cached = delegate.clone(orig, this, classCloner)) != null) {
-            clones.put(orig, cached);
+        if ((cached = delegate.clone(replaced, this, classCloner)) != null) {
+            clones.put(replaced, cached);
             return cached;
         }
-        final Class<? extends Object> objClass = orig.getClass();
+        final Class<? extends Object> objClass = replaced.getClass();
         final SerializableClass info = registry.lookup(objClass);
         if (replace) {
-            Object replaced = orig;
             if (info.hasWriteReplace()) {
                 replaced = info.callWriteReplace(replaced);
             }
@@ -246,11 +250,11 @@ class SerializingCloner implements ObjectCloner {
         } else {
             throw new NotSerializableException(objClass.getName());
         }
-        Object replaced = clone;
+        replaced = clone;
         if (cloneInfo.hasReadResolve()) {
             replaced = cloneInfo.callReadResolve(replaced);
         }
-        replaced = objectResolver.readResolve(replaced);
+        replaced = objectPreResolver.readResolve(objectResolver.readResolve(replaced));
         if (replaced != clone) clones.put(orig, replaced);
         return replaced;
     }

--- a/river/src/main/java/org/jboss/marshalling/river/RiverMarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverMarshaller.java
@@ -107,6 +107,7 @@ public class RiverMarshaller extends AbstractMarshaller {
     protected void doWriteObject(final Object original, final boolean unshared) throws IOException {
         final ClassExternalizerFactory classExternalizerFactory = this.classExternalizerFactory;
         final ObjectResolver objectResolver = this.objectResolver;
+        final ObjectResolver objectPreResolver = this.objectPreResolver;
         Object obj = original;
         Class<?> objClass;
         int id;
@@ -135,6 +136,8 @@ public class RiverMarshaller extends AbstractMarshaller {
                     }
                     return;
                 }
+                // Check for a global pre replacement, before any user replacement is called
+                obj = objectPreResolver.writeReplace(obj);
                 final ObjectTable.Writer objectTableWriter;
                 if (! unshared && (objectTableWriter = objectTable.getObjectWriter(obj)) != null) {
                     write(ID_PREDEFINED_OBJECT);

--- a/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
@@ -271,7 +271,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (unshared != (leadByte == ID_NEW_OBJECT_UNSHARED)) {
                         throw sharedMismatch();
                     }
-                    return doReadNewObject(readUnsignedByte(), unshared);
+                    return replace(doReadNewObject(readUnsignedByte(), unshared));
                 }
                 // v2 string types
                 case ID_STRING_EMPTY: {
@@ -317,7 +317,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     } else if (obj != resolvedObject) {
                         instanceCache.set(idx, resolvedObject);
                     }
-                    return obj;
+                    return replace(obj);
                 }
                 case ID_ARRAY_SMALL:
                 case ID_ARRAY_SMALL_UNSHARED: {
@@ -325,7 +325,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                         throw sharedMismatch();
                     }
                     final int len = readUnsignedByte();
-                    return doReadArray(len == 0 ? 0x100 : len, unshared);
+                    return replace(doReadArray(len == 0 ? 0x100 : len, unshared));
                 }
                 case ID_ARRAY_MEDIUM:
                 case ID_ARRAY_MEDIUM_UNSHARED: {
@@ -333,7 +333,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                         throw sharedMismatch();
                     }
                     final int len = readUnsignedShort();
-                    return doReadArray(len == 0 ? 0x10000 : len, unshared);
+                    return replace(doReadArray(len == 0 ? 0x10000 : len, unshared));
                 }
                 case ID_ARRAY_LARGE:
                 case ID_ARRAY_LARGE_UNSHARED: {
@@ -344,7 +344,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (len <= 0) {
                         throw new StreamCorruptedException("Invalid length value for array in stream (" + len + ")");
                     }
-                    return doReadArray(len, unshared);
+                    return replace(doReadArray(len, unshared));
                 }
                 case ID_PREDEFINED_OBJECT: {
                     if (unshared) {
@@ -353,31 +353,31 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     return objectTable.readObject(this);
                 }
                 case ID_BOOLEAN_OBJECT_TRUE: {
-                    return objectResolver.readResolve(Boolean.TRUE);
+                    return replace(objectResolver.readResolve(Boolean.TRUE));
                 }
                 case ID_BOOLEAN_OBJECT_FALSE: {
-                    return objectResolver.readResolve(Boolean.FALSE);
+                    return replace(objectResolver.readResolve(Boolean.FALSE));
                 }
                 case ID_BYTE_OBJECT: {
-                    return objectResolver.readResolve(Byte.valueOf(readByte()));
+                    return replace(objectResolver.readResolve(Byte.valueOf(readByte())));
                 }
                 case ID_SHORT_OBJECT: {
-                    return objectResolver.readResolve(Short.valueOf(readShort()));
+                    return replace(objectResolver.readResolve(Short.valueOf(readShort())));
                 }
                 case ID_INTEGER_OBJECT: {
-                    return objectResolver.readResolve(Integer.valueOf(readInt()));
+                    return replace(objectResolver.readResolve(Integer.valueOf(readInt())));
                 }
                 case ID_LONG_OBJECT: {
-                    return objectResolver.readResolve(Long.valueOf(readLong()));
+                    return replace(objectResolver.readResolve(Long.valueOf(readLong())));
                 }
                 case ID_FLOAT_OBJECT: {
-                    return objectResolver.readResolve(Float.valueOf(readFloat()));
+                    return replace(objectResolver.readResolve(Float.valueOf(readFloat())));
                 }
                 case ID_DOUBLE_OBJECT: {
-                    return objectResolver.readResolve(Double.valueOf(readDouble()));
+                    return replace(objectResolver.readResolve(Double.valueOf(readDouble())));
                 }
                 case ID_CHARACTER_OBJECT: {
-                    return objectResolver.readResolve(Character.valueOf(readChar()));
+                    return replace(objectResolver.readResolve(Character.valueOf(readChar())));
                 }
                 case ID_PRIM_BYTE: {
                     return byte.class;
@@ -562,7 +562,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (! unshared) {
                         instanceCache.set(idx, resolvedObject);
                     }
-                    return resolvedObject;
+                    return replace(resolvedObject);
                 }
                 case ID_SINGLETON_SET_OBJECT: {
                     final int idx = instanceCache.size();
@@ -572,7 +572,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (! unshared) {
                         instanceCache.set(idx, resolvedObject);
                     }
-                    return resolvedObject;
+                    return replace(resolvedObject);
                 }
                 case ID_SINGLETON_MAP_OBJECT: {
                     final int idx = instanceCache.size();
@@ -582,7 +582,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (! unshared) {
                         instanceCache.set(idx, resolvedObject);
                     }
-                    return resolvedObject;
+                    return replace(resolvedObject);
                 }
                 case ID_REVERSE_ORDER2_OBJECT: {
                     final int idx = instanceCache.size();
@@ -592,7 +592,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (! unshared) {
                         instanceCache.set(idx, resolvedObject);
                     }
-                    return resolvedObject;
+                    return replace(resolvedObject);
                 }
 
                 case ID_EMPTY_LIST_OBJECT: {
@@ -648,62 +648,62 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     final int id = readUnsignedByte();
                     switch (id) {
                         case ID_CC_ARRAY_LIST: {
-                            return readCollectionData(unshared, -1, len, new ArrayList(len));
+                            return replace(readCollectionData(unshared, -1, len, new ArrayList(len)));
                         }
                         case ID_CC_HASH_SET: {
-                            return readCollectionData(unshared, -1, len, new HashSet(len));
+                            return replace(readCollectionData(unshared, -1, len, new HashSet(len)));
                         }
                         case ID_CC_LINKED_HASH_SET: {
-                            return readCollectionData(unshared, -1, len, new LinkedHashSet(len));
+                            return replace(readCollectionData(unshared, -1, len, new LinkedHashSet(len)));
                         }
                         case ID_CC_LINKED_LIST: {
-                            return readCollectionData(unshared, -1, len, new LinkedList());
+                            return replace(readCollectionData(unshared, -1, len, new LinkedList()));
                         }
                         case ID_CC_TREE_SET: {
                             int idx = instanceCache.size();
                             instanceCache.add(null);
                             Comparator comp = (Comparator)doReadNestedObject(false, "java.util.TreeSet comparator");
-                            return readSortedSetData(unshared, idx, len, new TreeSet(comp));
+                            return replace(readSortedSetData(unshared, idx, len, new TreeSet(comp)));
                         }
                         case ID_CC_ENUM_SET_PROXY: {
                             final ClassDescriptor nestedDescriptor = doReadClassDescriptor(readUnsignedByte());
                             final Class<? extends Enum> elementType = nestedDescriptor.getType().asSubclass(Enum.class);
-                            return readCollectionData(unshared, -1, len, EnumSet.noneOf(elementType));
+                            return replace(readCollectionData(unshared, -1, len, EnumSet.noneOf(elementType)));
                         }
                         case ID_CC_VECTOR: {
-                            return readCollectionData(unshared, -1, len, new Vector(len));
+                            return replace(readCollectionData(unshared, -1, len, new Vector(len)));
                         }
                         case ID_CC_STACK: {
-                            return readCollectionData(unshared, -1, len, new Stack());
+                            return replace(readCollectionData(unshared, -1, len, new Stack()));
                         }
                         case ID_CC_ARRAY_DEQUE: {
-                            return readCollectionData(unshared, -1, len, new ArrayDeque(len));
+                            return replace(readCollectionData(unshared, -1, len, new ArrayDeque(len)));
                         }
 
                         case ID_CC_HASH_MAP: {
-                            return readMapData(unshared, -1, len, new HashMap(len));
+                            return replace(readMapData(unshared, -1, len, new HashMap(len)));
                         }
                         case ID_CC_HASHTABLE: {
-                            return readMapData(unshared, -1, len, new Hashtable(len));
+                            return replace(readMapData(unshared, -1, len, new Hashtable(len)));
                         }
                         case ID_CC_IDENTITY_HASH_MAP: {
-                            return readMapData(unshared, -1, len, new IdentityHashMap(len));
+                            return replace(readMapData(unshared, -1, len, new IdentityHashMap(len)));
                         }
                         case ID_CC_LINKED_HASH_MAP: {
-                            return readMapData(unshared, -1, len, new LinkedHashMap(len));
+                            return replace(readMapData(unshared, -1, len, new LinkedHashMap(len)));
                         }
                         case ID_CC_TREE_MAP: {
                             int idx = instanceCache.size();
                             instanceCache.add(null);
                             Comparator comp = (Comparator)doReadNestedObject(false, "java.util.TreeSet comparator");
-                            return readSortedMapData(unshared, idx, len, new TreeMap(comp));
+                            return replace(readSortedMapData(unshared, idx, len, new TreeMap(comp)));
                         }
                         case ID_CC_ENUM_MAP: {
                             int idx = instanceCache.size();
                             instanceCache.add(null);
                             final ClassDescriptor nestedDescriptor = doReadClassDescriptor(readUnsignedByte());
                             final Class<? extends Enum> elementType = nestedDescriptor.getType().asSubclass(Enum.class);
-                            return readMapData(unshared, idx, len, new EnumMap(elementType));
+                            return replace(readMapData(unshared, idx, len, new EnumMap(elementType)));
                         }
                         case ID_CC_NCOPIES: {
                             final int idx = instanceCache.size();
@@ -713,7 +713,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                             if (! unshared) {
                                 instanceCache.set(idx, resolvedObject);
                             }
-                            return resolvedObject;
+                            return replace(resolvedObject);
                         }
                         default: {
                             throw new StreamCorruptedException("Unexpected byte found when reading a collection type: " + leadByte);
@@ -729,7 +729,7 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     if (! unshared) {
                         instanceCache.set(idx, resolvedObject);
                     }
-                    return resolvedObject;
+                    return replace(resolvedObject);
                 }
 
                 case ID_CLEAR_CLASS_CACHE: {
@@ -1750,5 +1750,9 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
     public String readUTF() throws IOException {
         final int len = readInt();
         return UTFUtils.readUTFBytes(this, len);
+    }
+    
+    private Object replace(Object object) {
+        return objectPreResolver.readResolve(object);
     }
 }

--- a/serial/src/main/java/org/jboss/marshalling/serial/SerialMarshaller.java
+++ b/serial/src/main/java/org/jboss/marshalling/serial/SerialMarshaller.java
@@ -96,6 +96,7 @@ public final class SerialMarshaller extends AbstractMarshaller implements Marsha
         }
         final IdentityIntMap<Object> instanceCache = this.instanceCache;
         int v;
+        obj = objectPreResolver.writeReplace(obj);
         final ObjectTable.Writer writer;
         // - first check for cached objects, Classes, or ObjectStreamClass
         if (! unshared && (v = instanceCache.get(obj, -1)) != -1) {

--- a/serial/src/main/java/org/jboss/marshalling/serial/SerialUnmarshaller.java
+++ b/serial/src/main/java/org/jboss/marshalling/serial/SerialUnmarshaller.java
@@ -75,7 +75,7 @@ public final class SerialUnmarshaller extends AbstractUnmarshaller implements Un
     }
 
     protected Object doReadObject(final boolean unshared) throws ClassNotFoundException, IOException {
-        final Object obj = doReadObject(readUnsignedByte(), unshared);
+        final Object obj = objectPreResolver.readResolve((doReadObject(readUnsignedByte(), unshared)));
         if (depth == 0) try {
             for (Set<ObjectInputValidation> validations : validationMap.values()) {
                 for (ObjectInputValidation validation : validations) {

--- a/tests/src/test/java/org/jboss/test/marshalling/SimpleMarshallerTests.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/SimpleMarshallerTests.java
@@ -1954,12 +1954,38 @@ public final class SimpleMarshallerTests extends TestBase {
                 return original;
             }
         }
-
         public boolean ok() {
             return resolveVisited && replaceVisited;
         }
     }
 
+    public static class TestObjectPreResolver implements ObjectResolver {
+
+        private boolean writeReplaceVisited;
+        private boolean readReplaceVisited;
+
+        public Object readResolve(Object replacement) {
+        	if (replacement instanceof Integer) {
+        		readReplaceVisited = true;
+        	}
+        	return replacement;
+        }
+
+        public Object writeReplace(Object original) {
+            if (original instanceof TestSerializable) {
+                writeReplaceVisited = true;
+                return new Integer(17);
+            } else {
+                return original;
+            }
+        }
+        
+        public boolean ok() {
+            return writeReplaceVisited && readReplaceVisited;
+        }
+    }
+
+    
     /**
      * Verify that use of customized ObjectResolver works correctly.
      */
@@ -1984,6 +2010,34 @@ public final class SimpleMarshallerTests extends TestBase {
 
             public void runRead(final Unmarshaller unmarshaller) throws Throwable {
                 assertEquals(serializable, unmarshaller.readObject());
+                assertEOF(unmarshaller);
+            }
+        });
+        assertTrue(objectResolver.ok());
+    }
+    
+    @Test
+    public void testObjectPreResolver() throws Throwable {
+        if (testMarshallerProvider instanceof ObjectOutputStreamTestMarshallerProvider) {
+            throw new SkipException("Can't use objectPreResolver in compatibility tests");
+        }
+        if (testUnmarshallerProvider instanceof ObjectInputStreamTestUnmarshallerProvider) {
+            throw new SkipException("Can't use objectPreResolver in compatibility tests");
+        }
+        final TestObjectPreResolver objectResolver = new TestObjectPreResolver();
+        final TestSerializable serializable = new TestSerializable();
+        final Integer expectedObj = new Integer(17);
+        runReadWriteTest(new ReadWriteTest() {
+            public void configure(final MarshallingConfiguration configuration) throws Throwable {
+                configuration.setObjectPreResolver(objectResolver);
+            }
+
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject(serializable);
+            }
+
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                assertEquals(expectedObj, unmarshaller.readObject());
                 assertEOF(unmarshaller);
             }
         });
@@ -2144,6 +2198,10 @@ public final class SimpleMarshallerTests extends TestBase {
             } else {
                 return original;
             }
+        }
+        
+        public Object preWriteReplace(Object original) {
+            return original;
         }
 
         public boolean ok() {


### PR DESCRIPTION
JBMAR-149 : Support for hook into the serialization processwith ObjectResolver before the user replacement is called

Added an extra hook to the ObjectResolver interface to be called before ObjectTable lookup. I'm not sure about the name of the hook "preWriteReplace" but it's the best name I could come up with. 

I'm unsure about the changes to SerializingCloner is the right approach, but it make sense to call it inside the replace block to prevent infinity loop
