### PR TITLE
[JBMAR-160] : SimpleMarshallerTests.testConcurrentHashMap fails on Java 8

### DIFF
--- a/serial/src/main/java/org/jboss/marshalling/serial/PlainDescriptor.java
+++ b/serial/src/main/java/org/jboss/marshalling/serial/PlainDescriptor.java
@@ -40,6 +40,8 @@ import java.io.StreamCorruptedException;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  *
@@ -107,47 +109,89 @@ class PlainDescriptor extends Descriptor implements ObjectStreamConstants {
         try {
             // first primitive fields
             for (SerializableField serializableField : fields) {
-                final Field realField = serializableField.getField();
-                if (realField != null) switch (serializableField.getKind()) {
-                    case BOOLEAN: {
-                        realField.setBoolean(subject, serialUnmarshaller.readBoolean());
-                        break;
+                final Field field = serializableField.getField();
+                if (field == null) {
+                    // missing; consume stream data only
+                    switch (serializableField.getKind()) {
+                        case BOOLEAN: {
+                            serialUnmarshaller.readBoolean();
+                            break;
+                        }
+                        case BYTE: {
+                            serialUnmarshaller.readByte();
+                            break;
+                        }
+                        case CHAR: {
+                            serialUnmarshaller.readChar();
+                            break;
+                        }
+                        case DOUBLE: {
+                            serialUnmarshaller.readDouble();
+                            break;
+                        }
+                        case FLOAT: {
+                            serialUnmarshaller.readFloat();
+                            break;
+                        }
+                        case INT: {
+                            serialUnmarshaller.readInt();
+                            break;
+                        }
+                        case LONG: {
+                            serialUnmarshaller.readLong();
+                            break;
+                        }
+                        case SHORT: {
+                            serialUnmarshaller.readShort();
+                            break;
+                        }
                     }
-                    case BYTE: {
-                        realField.setByte(subject, serialUnmarshaller.readByte());
-                        break;
-                    }
-                    case CHAR: {
-                        realField.setChar(subject, serialUnmarshaller.readChar());
-                        break;
-                    }
-                    case DOUBLE: {
-                        realField.setDouble(subject, serialUnmarshaller.readDouble());
-                        break;
-                    }
-                    case FLOAT: {
-                        realField.setFloat(subject, serialUnmarshaller.readFloat());
-                        break;
-                    }
-                    case INT: {
-                        realField.setInt(subject, serialUnmarshaller.readInt());
-                        break;
-                    }
-                    case LONG: {
-                        realField.setLong(subject, serialUnmarshaller.readLong());
-                        break;
-                    }
-                    case SHORT: {
-                        realField.setShort(subject, serialUnmarshaller.readShort());
-                        break;
+                }else{
+                    final Field realField = serializableField.getField();
+
+                    if (realField != null) switch (serializableField.getKind()) {
+                        case BOOLEAN: {
+                            realField.setBoolean(subject, serialUnmarshaller.readBoolean());
+                            break;
+                        }
+                        case BYTE: {
+                            realField.setByte(subject, serialUnmarshaller.readByte());
+                            break;
+                        }
+                        case CHAR: {
+                            realField.setChar(subject, serialUnmarshaller.readChar());
+                            break;
+                        }
+                        case DOUBLE: {
+                            realField.setDouble(subject, serialUnmarshaller.readDouble());
+                            break;
+                        }
+                        case FLOAT: {
+                            realField.setFloat(subject, serialUnmarshaller.readFloat());
+                            break;
+                        }
+                        case INT: {
+                            realField.setInt(subject, serialUnmarshaller.readInt());
+                            break;
+                        }
+                        case LONG: {
+                            realField.setLong(subject, serialUnmarshaller.readLong());
+                            break;
+                        }
+                        case SHORT: {
+                            realField.setShort(subject, serialUnmarshaller.readShort());
+                            break;
+                        }
                     }
                 }
             }
+            
             // next object fields
             for (SerializableField serializableField : fields) {
                 if (serializableField.getKind() == Kind.OBJECT) {
                     final Field realField = serializableField.getField();
                     if (realField !=  null) realField.set(subject, serialUnmarshaller.readObject());
+                    else serialUnmarshaller.readObject(); // missing; consume stream data only
                 }
             }
         } catch (IllegalAccessException e) {

--- a/serial/src/main/java/org/jboss/marshalling/serial/SerialObjectOutputStream.java
+++ b/serial/src/main/java/org/jboss/marshalling/serial/SerialObjectOutputStream.java
@@ -128,9 +128,11 @@ final class SerialObjectOutputStream extends MarshallerObjectOutputStream {
         state = State.ON;
     }
 
+    Map<String, FieldPutter> map;
+    
     public PutField putFields() throws IOException {
         if (state == State.NEW) {
-            final Map<String, FieldPutter> map = new TreeMap<String, FieldPutter>();
+            map = new TreeMap<String, FieldPutter>();
             currentFieldMap = map;
             for (SerializableField serializableField : currentSerializableClass.getFields()) {
                 final FieldPutter putter;
@@ -178,59 +180,58 @@ final class SerialObjectOutputStream extends MarshallerObjectOutputStream {
                 map.put(serializableField.getName(), putter);
             }
             state = State.FIELDS;
-            return new PutField() {
-                public void put(final String name, final boolean val) {
-                    find(name).setBoolean(val);
-                }
-
-                public void put(final String name, final byte val) {
-                    find(name).setByte(val);
-                }
-
-                public void put(final String name, final char val) {
-                    find(name).setChar(val);
-                }
-
-                public void put(final String name, final short val) {
-                    find(name).setShort(val);
-                }
-
-                public void put(final String name, final int val) {
-                    find(name).setInt(val);
-                }
-
-                public void put(final String name, final long val) {
-                    find(name).setLong(val);
-                }
-
-                public void put(final String name, final float val) {
-                    find(name).setFloat(val);
-                }
-
-                public void put(final String name, final double val) {
-                    find(name).setDouble(val);
-                }
-
-                public void put(final String name, final Object val) {
-                    find(name).setObject(val);
-                }
-
-                @Deprecated
-                public void write(final ObjectOutput out) throws IOException {
-                    throw new UnsupportedOperationException("write(ObjectOutput)");
-                }
-
-                private FieldPutter find(final String name) {
-                    final FieldPutter putter = map.get(name);
-                    if (putter == null) {
-                        throw new IllegalArgumentException("No field named '" + name + "' found");
-                    }
-                    return putter;
-                }
-            };
-        } else {
-            throw new IllegalStateException("putFields() may not be called now");
         }
+        
+        return new PutField() {
+            public void put(final String name, final boolean val) {
+                find(name).setBoolean(val);
+            }
+
+            public void put(final String name, final byte val) {
+                find(name).setByte(val);
+            }
+
+            public void put(final String name, final char val) {
+                find(name).setChar(val);
+            }
+
+            public void put(final String name, final short val) {
+                find(name).setShort(val);
+            }
+
+            public void put(final String name, final int val) {
+                find(name).setInt(val);
+            }
+
+            public void put(final String name, final long val) {
+                find(name).setLong(val);
+            }
+
+            public void put(final String name, final float val) {
+                find(name).setFloat(val);
+            }
+
+            public void put(final String name, final double val) {
+                find(name).setDouble(val);
+            }
+
+            public void put(final String name, final Object val) {
+                 find(name).setObject(val);
+            }
+
+            @Deprecated
+            public void write(final ObjectOutput out) throws IOException {
+                throw new UnsupportedOperationException("write(ObjectOutput)");
+            }
+
+            private FieldPutter find(final String name) {
+                final FieldPutter putter = map.get(name);
+                if (putter == null) {
+                    throw new IllegalArgumentException("No field named '" + name + "' found");
+                }
+                return putter;
+            }
+        };
     }
 
     public void defaultWriteObject() throws IOException {


### PR DESCRIPTION
The ConcurrentHashMap class has been changed in JDK8.
The fields segments, segmentMask and segmentShift are part of serialPersistentFields.
Solution : Consumption of empty-field stream data in the SerialUnmarshalling, the same way it is done with the RiverUnmarshaller.

[BZ 1074546] : https://bugzilla.redhat.com/show_bug.cgi?id=1074546
