### PR TITLE
Improving error diagnostics.

### DIFF
--- a/api/src/main/java/org/jboss/marshalling/TraceInformation.java
+++ b/api/src/main/java/org/jboss/marshalling/TraceInformation.java
@@ -18,6 +18,9 @@
 
 package org.jboss.marshalling;
 
+import org.jboss.marshalling.reflect.SerializableClass;
+import org.jboss.marshalling.reflect.SerializableField;
+
 import java.io.Serializable;
 
 /**
@@ -103,6 +106,19 @@ public final class TraceInformation extends Throwable {
         final TraceInformation ti = getOrAddTraceInformation(t);
         final Info oldInfo = ti.info;
         ti.info = new FieldInfo(oldInfo, fieldName);
+    }
+
+    /**
+     * Add information about a field which was being marshalled.
+     *
+     * @param t the throwable to update
+     * @param owner
+     *      Reference to the class that owns the field.
+     * @param field
+     *      The field being (un-)marshalled.
+     */
+    public static void addFieldInformation(Throwable t, SerializableClass owner, SerializableField field) {
+        addFieldInformation(t,owner.getSubjectClass().getName()+"."+field.getName());
     }
 
     /**

--- a/river/src/main/java/org/jboss/marshalling/river/RiverMarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverMarshaller.java
@@ -1039,10 +1039,12 @@ public class RiverMarshaller extends AbstractMarshaller {
                     throw ioe;
                 }
             } catch (IOException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, info, serializableField);
+                TraceInformation.addObjectInformation(e, obj);
                 throw e;
             } catch (RuntimeException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, info, serializableField);
+                TraceInformation.addObjectInformation(e, obj);
                 throw e;
             }
         }
@@ -1091,10 +1093,10 @@ public class RiverMarshaller extends AbstractMarshaller {
                     }
                 }
             } catch (IOException e){
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, info, serializableField);
                 throw e;
             } catch (RuntimeException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, info, serializableField);
                 throw e;
             }
         }

--- a/river/src/main/java/org/jboss/marshalling/river/RiverObjectInputStream.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverObjectInputStream.java
@@ -164,13 +164,13 @@ public class RiverObjectInputStream extends MarshallerObjectInputStream {
                         throw new IllegalStateException("Wrong field type");
                 }
             } catch (IOException e) {
-                TraceInformation.addFieldInformation(e, field.getName());
+                TraceInformation.addFieldInformation(e, serializableClassDescriptor.getSerializableClass(), field);
                 throw e;
             } catch (ClassNotFoundException e) {
-                TraceInformation.addFieldInformation(e, field.getName());
+                TraceInformation.addFieldInformation(e, serializableClassDescriptor.getSerializableClass(), field);
                 throw e;
             } catch (RuntimeException e) {
-                TraceInformation.addFieldInformation(e, field.getName());
+                TraceInformation.addFieldInformation(e, serializableClassDescriptor.getSerializableClass(), field);
                 throw e;
             }
         }

--- a/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
@@ -1756,13 +1756,16 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     throw ioe;
                 }
             } catch (IOException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
+                TraceInformation.addObjectInformation(e, obj);
                 throw e;
             } catch (ClassNotFoundException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
+                TraceInformation.addObjectInformation(e, obj);
                 throw e;
             } catch (RuntimeException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
+                TraceInformation.addObjectInformation(e, obj);
                 throw e;
             }
         }
@@ -1810,13 +1813,13 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                     }
                 }
             } catch (IOException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
                 throw e;
             } catch (ClassNotFoundException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
                 throw new IOException("Failed to discard field data", e);
             } catch (RuntimeException e) {
-                TraceInformation.addFieldInformation(e, serializableField.getName());
+                TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
                 throw e;
             }
         }


### PR DESCRIPTION
In case of non-serializable object, river marshaller tries to print out
the path into the object in question. This is great, but right now the
exception message is rather unhelpful.

See the following example that I just had. The problem is that the field name
is not qualified by the owner class name, so I still can't quite figure out how this object
in question is referenced. This change improves the situation by prepending the field name
by the name of the owning class. In addition, object info is also added wherever possible,
to further improve the diagnostics:

```
java.io.NotSerializableException: org.jenkinsci.plugins.workflow.steps.ExceptionCause
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:890)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:808)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:997)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:997)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:997)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:997)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:997)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:997)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:679)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1062)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1018)
    at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:884)
    at org.jboss.marshalling.AbstractObjectOutput.writeObject(AbstractObjectOutput.java:58)
    at org.jboss.marshalling.AbstractMarshaller.writeObject(AbstractMarshaller.java:111)
    at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter.writeObject(RiverWriter.java:128)
    at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:345)
    at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:329)
    at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:303)
    at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:72)
    at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$3.call(CpsThreadGroup.java:184)
    at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$3.call(CpsThreadGroup.java:182)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603)
    at java.lang.Thread.run(Thread.java:722)
    at org.jenkinsci.plugins.workflow.cps.CpsVmThread.run(CpsVmThread.java:21)
Caused by: an exception which occurred:
    in field a
    in field causes
    in field stopped
    in field body
    in field step
    in field thread
    in field callback
    in field returnAddress
    in field parent
    in field caller
    in field parent
    in field capture
    in field def
    in field delegate
    in field closures
    in object org.jenkinsci.plugins.workflow.cps.CpsThreadGroup@323b082b
```
