### PR TITLE
[WFLY-2717] : Exceptions returned from remote ejb calls create ClassCastException

### DIFF
--- a/river/src/main/java/org/jboss/marshalling/river/Protocol.java
+++ b/river/src/main/java/org/jboss/marshalling/river/Protocol.java
@@ -28,6 +28,7 @@ public final class Protocol {
     public static final int MIN_VERSION = 2;
     public static final int MAX_VERSION = 3;
 
+    public static final int ID_LEADBYTE_0               = 0x0;
     public static final int ID_NULL                     = 0x01;
     public static final int ID_REPEAT_OBJECT_FAR        = 0x02;
     public static final int ID_PREDEFINED_OBJECT        = 0x03;

--- a/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
@@ -229,6 +229,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
         depth ++;
         try {
             for (;;) switch (leadByte) {
+                case ID_LEADBYTE_0:
+                    return "LEADBYTE_0";
                 case ID_NULL: {
                     return null;
                 }


### PR DESCRIPTION
Adding the ID_LEADBYTE_0, to be used in case an exception is thrown.
