### PR TITLE
[1.4 branch] Fix for JBMAR-181 

### DIFF
--- a/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
@@ -1279,7 +1279,14 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                 case ID_SERIALIZABLE_CLASS: {
                     final SerializableClassDescriptor serializableClassDescriptor = (SerializableClassDescriptor) descriptor;
                     final SerializableClass serializableClass = serializableClassDescriptor.getSerializableClass();
-                    final Object obj = serializableClass == null ? null : serializableClass.callNonInitConstructor();
+                    final Object obj;
+                    if(serializableClass == null) {
+                        obj = null;
+                    } else if (!serializableClass.hasNoInitConstructor()) {
+                        throw new NotSerializableException(serializableClass.getSubjectClass().getName());
+                    } else {
+                        obj = serializableClass.callNonInitConstructor();
+                    }
                     final int idx = instanceCache.size();
                     instanceCache.add(obj);
                     doInitSerializable(obj, serializableClassDescriptor, discardMissing);


### PR DESCRIPTION
The commit here fixes the NullPointerException reported in https://issues.jboss.org/browse/JBMAR-181. As noted in the JIRA, this now throws a more appropriate `NotSerializableException`
