### PR TITLE
[JBMAR-191] Use correct class loader when passing a class to callNonInitConstructor in SerializingCloner

### DIFF
--- a/api/src/main/java/org/jboss/marshalling/cloner/SerializingCloner.java
+++ b/api/src/main/java/org/jboss/marshalling/cloner/SerializingCloner.java
@@ -238,9 +238,9 @@ class SerializingCloner implements ObjectCloner {
             externalizable.writeExternal(soo);
             soo.doFinish();
             ((Externalizable) clone).readExternal(new StepObjectInput(steps));
-        } else if (serializabilityChecker.isSerializable(objClass)) {
+        } else if (serializabilityChecker.isSerializable(clonedClass)) {
             Class<?> nonSerializable;
-            for (nonSerializable = objClass.getSuperclass(); serializabilityChecker.isSerializable(nonSerializable); nonSerializable = nonSerializable.getSuperclass()) {
+            for (nonSerializable = clonedClass.getSuperclass(); serializabilityChecker.isSerializable(nonSerializable); nonSerializable = nonSerializable.getSuperclass()) {
                 if (nonSerializable == Object.class) break;
             }
             clone = cloneInfo.callNonInitConstructor(nonSerializable);


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBMAR-191 for details