### PR TITLE
[BZ-1456503] {NullPointerException while deserializing an object whose class doesn't have a no-arg constructor}

### DIFF
--- a/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
@@ -1279,7 +1279,15 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                 case ID_SERIALIZABLE_CLASS: {
                     final SerializableClassDescriptor serializableClassDescriptor = (SerializableClassDescriptor) descriptor;
                     final SerializableClass serializableClass = serializableClassDescriptor.getSerializableClass();
-                    final Object obj = serializableClass == null ? null : serializableClass.callNonInitConstructor();
+                    final Object obj;
+                    if(serializableClass == null) {
+                        obj = null;
+                    } else if (!serializableClass.hasNoInitConstructor()) {
+                        throw new NotSerializableException(serializableClass.getSubjectClass().getName());
+                    } else {
+                        obj = serializableClass.callNonInitConstructor();
+                    }
+
                     final int idx = instanceCache.size();
                     instanceCache.add(obj);
                     doInitSerializable(obj, serializableClassDescriptor, discardMissing);


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1456503

Upstream: https://issues.jboss.org/browse/JBEAP-11197
Upstream PR: https://github.com/jboss-remoting/jboss-marshalling/pull/47
