### PR TITLE
BZ-1456505 Using internal JDK classes causes issues on recent JDK9 builds

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,6 +36,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-jdk9-supplement</artifactId>
+            <version>1.0.Final</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
             <scope>provided</scope>
@@ -56,9 +68,34 @@
                 </includes>
                 <filtering>true</filtering>
             </resource>
+            <resource>
+                <directory>target/generated-resources</directory>
+                <filtering>false</filtering>
+            </resource>
         </resources>
 
         <plugins>
+            <!-- Remote resources -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-java9-supplement</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.jboss.marshalling</includeGroupIds>
+                            <includeArtifactIds>jboss-marshalling-jdk9-supplement</includeArtifactIds>
+                            <excludeTransitive>true</excludeTransitive>
+                            <includes>**/*.class</includes>
+                            <outputDirectory>${project.build.directory}/generated-resources/META-INF/versions/9</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- JAR -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
@@ -66,6 +103,9 @@
                         <manifest>
                             <mainClass>org.jboss.marshalling.Version</mainClass>
                         </manifest>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/api/src/main/java/org/jboss/marshalling/reflect/JDKSpecific.java
+++ b/api/src/main/java/org/jboss/marshalling/reflect/JDKSpecific.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.marshalling.reflect;
+
+import java.lang.reflect.Constructor;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import sun.reflect.ReflectionFactory;
+
+/**
+ * JDK-specific classes which are replaced for different JDK major versions. This one is for Java 8 only.
+ *
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class JDKSpecific {
+
+    private static final ReflectionFactory reflectionFactory = AccessController.doPrivileged(new PrivilegedAction<ReflectionFactory>() {
+        public ReflectionFactory run() { return ReflectionFactory.getReflectionFactory(); }
+    });
+
+    static Constructor<?> newConstructorForSerialization(Class<?> classToInstantiate, Constructor<?> constructorToCall) {
+        return reflectionFactory.newConstructorForSerialization(classToInstantiate, constructorToCall);
+    }
+
+}

--- a/api/src/main/java/org/jboss/marshalling/reflect/SerializableClass.java
+++ b/api/src/main/java/org/jboss/marshalling/reflect/SerializableClass.java
@@ -31,23 +31,19 @@ import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.ObjectStreamField;
 import java.io.ObjectStreamClass;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import sun.reflect.ReflectionFactory;
 
 /**
  * Reflection information about a serializable class.  Intended for use by implementations of the Marshalling API.
+ *
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public final class SerializableClass {
-    private static final ReflectionFactory reflectionFactory = AccessController.doPrivileged(new PrivilegedAction<ReflectionFactory>() {
-        public ReflectionFactory run() { return ReflectionFactory.getReflectionFactory(); }
-    });
     private final Class<?> subject;
     private final Method writeObject;
     private final Method writeReplace;
@@ -555,7 +551,7 @@ public final class SerializableClass {
             return null;
         }
         topConstructor.setAccessible(true);
-        final Constructor<T> generatedConstructor = (Constructor<T>) reflectionFactory.newConstructorForSerialization(subject, topConstructor);
+        final Constructor<T> generatedConstructor = (Constructor<T>) JDKSpecific.newConstructorForSerialization(subject, topConstructor);
         generatedConstructor.setAccessible(true);
         return generatedConstructor;
     }

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -26,7 +26,7 @@
     <description>JBoss Marshalling OSGi Bundle with API and implementations</description>
     <groupId>org.jboss.marshalling</groupId>
     <artifactId>jboss-marshalling-osgi</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.jboss.marshalling</groupId>
@@ -36,6 +36,8 @@
 
     <properties>
         <bundle.namespace>org.jboss.marshalling</bundle.namespace>
+        <intermediary_jar_name>intermediary-${project.build.finalName}</intermediary_jar_name>
+        <intermediary_jar_path>${project.build.directory}/${intermediary_jar_name}.jar</intermediary_jar_path>
     </properties>
 
     <dependencies>
@@ -62,11 +64,22 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>none-default</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>org.jboss.marshalling:jboss-marshalling</artifact>
+                                    <excludes>
+                                        <!-- org.apache.felix:maven-bundle-plugin chokes on Multi-Version jar content :( -->
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <finalName>${intermediary_jar_name}</finalName>
                             <createSourcesJar>true</createSourcesJar>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <transformers>
@@ -82,18 +95,32 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-DocURL>http://jboss.org/jbossmarshalling</Bundle-DocURL>
-                        <Import-Package>org.jboss.modules.*;sun.reflect.*;resolution:=optional</Import-Package>
-                        <Export-Package>org.jboss.marshalling.*;version=${project.version};-split-package:=error</Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-bundle</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>bundle-package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Include-Resource>@${intermediary_jar_path}</Include-Resource>
+                                <Bundle-DocURL>http://jboss.org/jbossmarshalling</Bundle-DocURL>
+                                <Import-Package>org.jboss.modules.*;sun.reflect.*;resolution:=optional</Import-Package>
+                                <Export-Package>org.jboss.marshalling.*;version=${project.version};-split-package:=error</Export-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,15 +53,12 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>1.4</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                        </execution>
-                    </executions>
+                    <version>2.4.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jboss.maven.plugins</groupId>


### PR DESCRIPTION
No upstream required

Cherry picked from branch 1.4.
Original issue: https://issues.jboss.org/browse/JBMAR-190