### PR TITLE
JBMAR-226 apply serializabilityChecker to inner classes as well

### DIFF
--- a/tests/src/test/java/org/jboss/test/marshalling/NonSerializableClass.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/NonSerializableClass.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.test.marshalling;
+
+/**
+ * @author wangc
+ *
+ */
+public class NonSerializableClass {
+
+    private String str;
+
+    public NonSerializableClass(String str) {
+        this.str = str;
+    }
+
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof NonSerializableClass)) {
+            return false;
+        }
+        NonSerializableClass c = (NonSerializableClass) o;
+        return str.equals(c.str);
+    }
+
+}

--- a/tests/src/test/java/org/jboss/test/marshalling/SerializableClass.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/SerializableClass.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.test.marshalling;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author wangc
+ *
+ */
+public class SerializableClass implements Serializable {
+
+    private static final long serialVersionUID = -4653225564318177939L;
+
+    private String str;
+    private List<NonSerializableClass> list = new ArrayList<>();
+
+    public SerializableClass(String str) {
+        this.str = str;
+        list = Arrays.asList(new NonSerializableClass(str));
+    }
+
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof SerializableClass)) {
+            return false;
+        }
+        SerializableClass c = (SerializableClass) o;
+        return str.equals(c.str) && ((list == null) ? c.list == null : list.equals(c.list));
+    }
+}

--- a/tests/src/test/java/org/jboss/test/marshalling/SingleObjectMarshallerTestFactory.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/SingleObjectMarshallerTestFactory.java
@@ -159,6 +159,7 @@ public final class SingleObjectMarshallerTestFactory {
         list.add("This is a string");
         list.add(new TestComplexObject(true, (byte)5, 'c', (short)8192, 294902, 319203219042L, 21.125f, 42.625, "TestString", new HashSet<Object>(Arrays.asList("Hello", Boolean.TRUE, Integer.valueOf(12345)))));
         list.add(new TestComplexExternalizableObject(true, (byte)5, 'c', (short)8192, 294902, 319203219042L, 21.125f, 42.625, "TestString", new HashSet<Object>(Arrays.asList("Hello", Boolean.TRUE, Integer.valueOf(12345)))));
+        list.add(new SerializableClass("test"));
         list.add(Collections.unmodifiableMap(new HashMap<Object, Object>()));
         list.add(Collections.unmodifiableMap(Collections.singletonMap("hi", "there")).entrySet());
         list.add(Collections.unmodifiableSet(new HashSet<Object>()));

--- a/tests/src/test/java/org/jboss/test/marshalling/SingleObjectMarshallerTests.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/SingleObjectMarshallerTests.java
@@ -18,6 +18,7 @@
 
 package org.jboss.test.marshalling;
 
+import java.io.NotSerializableException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -66,6 +67,16 @@ public final class SingleObjectMarshallerTests extends TestBase {
                 if (subject instanceof TestArrayList && marshaller instanceof RiverMarshaller && configuration.getVersion() == -1) {
                     throw new SkipException("TODO Known Issue - JBMAR-61");
                 }
+
+                if (subject instanceof SerializableClass) {
+                    try {
+                        marshaller.writeObject(subject);
+                        throw new RuntimeException("SerializableClass should fail with NotSerializableException");
+                    } catch (NotSerializableException e) {
+                        // expected
+                        return;
+                    }
+                }
                 marshaller.writeObject(subject);
                 marshaller.writeObject(subject);
                 marshaller.writeObject("Test follower");
@@ -98,6 +109,10 @@ public final class SingleObjectMarshallerTests extends TestBase {
                     e2.setStackTrace(e.getStackTrace());
                     throw e2;
                 } catch (Throwable t) {
+                    if (subject instanceof SerializableClass) {
+                        // expected and ignore exception as there is NotSerializableException in write
+                        return;
+                    }
                     throw new RuntimeException(String.format("Throwable occurred.\n\t-- Subject is %s\n\t-- Read Subject is %s\n\t-- Second object is %s\n\t-- Unmarshaller is %s\n\t-- Config is %s",
                             stringOf(subject),
                             stringOf(readSubject),


### PR DESCRIPTION
https://issues.jboss.org/browse/JBMAR-226
Under the `ID_SERIALIZABLE_CLASS` case, apply serializabilityChecker to inner classes as well, otherwise, it can cause `java.io.EOFException: Read past end of file` because inner classes miss Serializable declaration.