### PR TITLE
[JBMAR-241] Support serialization of java record type

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,7 +34,7 @@
     </parent>
 
     <properties>
-        <jdk.min.version>9</jdk.min.version>
+        <jdk.min.version>16</jdk.min.version>
     </properties>
 
     <dependencies>
@@ -126,6 +126,22 @@
                             <buildDirectory>${project.build.directory}</buildDirectory>
                             <compileSourceRoots>${project.basedir}/src/main/java9</compileSourceRoots>
                             <outputDirectory>${project.build.directory}/classes/META-INF/versions/9</outputDirectory>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
+                            </additionalClasspathElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-java16</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>16</release>
+                            <buildDirectory>${project.build.directory}</buildDirectory>
+                            <compileSourceRoots>${project.basedir}/src/main/java16</compileSourceRoots>
+                            <outputDirectory>${project.build.directory}/classes/META-INF/versions/16</outputDirectory>
                             <additionalClasspathElements>
                                 <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
                             </additionalClasspathElements>

--- a/api/src/main/java/org/jboss/marshalling/reflect/JDKSpecific.java
+++ b/api/src/main/java/org/jboss/marshalling/reflect/JDKSpecific.java
@@ -61,6 +61,49 @@ final class JDKSpecific {
         return serCtor;
     }
 
+    /**
+     * Return if this class is a record type.
+     * @param type The class type
+     * @return true if the class is a record, false otherwise
+     */
+    static boolean isRecord(Class<?> type) {
+        // in java previous 16 is false
+        return false;
+    }
+
+    /**
+     * Returns an ordered array of the record components for the given record
+     * class.
+     * @param type The record class
+     * @return The record components array for this class
+     */
+    static SerializableField.RecordComponent[] getRecordComponents(Class<?> type) {
+        throw new UnsupportedOperationException("Records not supported in this version of java");
+    }
+
+    /**
+     * Retrieves the value of the record component for the given record object.
+     * @param recordObject The record Object
+     * @param name The record component name
+     * @param type The record component class type
+     * @return The record component for this record object
+     */
+    static Object getRecordComponentValue(Object recordObject, String name, Class<?> type) {
+        throw new UnsupportedOperationException("Records not supported in this version of java");
+    }
+
+    /**
+     * Invokes the canonical constructor of a record class with the
+     * given argument values.
+     * @param recordType The record class
+     * @param fields The fields of the record class
+     * @param args The arguments for the constructor
+     * @return The instantiated object
+     */
+    static Object invokeRecordCanonicalConstructor(Class<?> recordType, SerializableField[] fields, Object[] args) {
+        throw new UnsupportedOperationException("Records not supported in this version of java");
+    }
+
     static final class SerMethods {
         private final Method readObject;
         private final Method readObjectNoData;

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <jdk.min.version>9</jdk.min.version>
+        <jdk.min.version>1.8</jdk.min.version>
     </properties>
 
     <modules>

--- a/river/src/main/java/org/jboss/marshalling/river/RiverMarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverMarshaller.java
@@ -265,7 +265,11 @@ public class RiverMarshaller extends AbstractMarshaller {
                 write(unshared ? ID_NEW_OBJECT_UNSHARED : ID_NEW_OBJECT);
                 writeSerializableClass(objClass, false);
                 instanceCache.put(obj, instanceSeq++);
-                doWriteSerializableObject(info, obj, objClass);
+                if (info != null && info.isRecord()) {
+                    doWriteRecord(obj, info);
+                } else {
+                    doWriteSerializableObject(info, obj, objClass);
+                }
                 if (unshared) {
                     instanceCache.put(obj, -1);
                 }
@@ -332,6 +336,41 @@ public class RiverMarshaller extends AbstractMarshaller {
             instanceCache.put(obj, -1);
         }
         return;
+    }
+
+    private void doWriteRecord(Object object, SerializableClass info) throws IOException {
+        final SerializableField[] serializableFields = info.getFields();
+        for (SerializableField serializableField : serializableFields) {
+            switch (serializableField.getKind()) {
+                case BOOLEAN:
+                    writeBoolean((boolean) serializableField.getRecordComponentValue(object));
+                    break;
+                case BYTE:
+                    writeByte((byte) serializableField.getRecordComponentValue(object));
+                    break;
+                case SHORT:
+                    writeShort((short) serializableField.getRecordComponentValue(object));
+                    break;
+                case INT:
+                    writeInt((int) serializableField.getRecordComponentValue(object));
+                    break;
+                case CHAR:
+                    writeChar((char) serializableField.getRecordComponentValue(object));
+                    break;
+                case LONG:
+                    writeLong((long) serializableField.getRecordComponentValue(object));
+                    break;
+                case DOUBLE:
+                    writeDouble((double) serializableField.getRecordComponentValue(object));
+                    break;
+                case FLOAT:
+                    writeFloat((float) serializableField.getRecordComponentValue(object));
+                    break;
+                case OBJECT:
+                    doWriteObject(serializableField.getRecordComponentValue(object), serializableField.isUnshared());
+                    break;
+            }
+        }
     }
 
     private void writeKnownObject(boolean unshared, Object obj, Class<?> objClass, int id) throws IOException {

--- a/serial/src/main/java/org/jboss/marshalling/serial/SerialMarshaller.java
+++ b/serial/src/main/java/org/jboss/marshalling/serial/SerialMarshaller.java
@@ -298,6 +298,8 @@ public final class SerialMarshaller extends AbstractMarshaller implements Marsha
                 oos.restoreState(oldState);
             }
             doEndBlock();
+        } else if (sc.isRecord()) {
+            doWriteRecord(sc, obj);
         } else {
             doWriteFields(sc, obj);
         }
@@ -326,6 +328,42 @@ public final class SerialMarshaller extends AbstractMarshaller implements Marsha
             oos = createObjectOutputStream();
         }
         return oos;
+    }
+
+    private void doWriteRecord(final SerializableClass info, final Object obj) throws IOException {
+        for (SerializableField serializableField : info.getFields()) {
+            switch (serializableField.getKind()) {
+                case BOOLEAN:
+                    writeBoolean((boolean) serializableField.getRecordComponentValue(obj));
+                    break;
+                case BYTE:
+                    writeByte((byte) serializableField.getRecordComponentValue(obj));
+                    break;
+                case SHORT:
+                    writeShort((short) serializableField.getRecordComponentValue(obj));
+                    break;
+                case INT:
+                    writeInt((int) serializableField.getRecordComponentValue(obj));
+                    break;
+                case CHAR:
+                    writeChar((char) serializableField.getRecordComponentValue(obj));
+                    break;
+                case LONG:
+                    writeLong((long) serializableField.getRecordComponentValue(obj));
+                    break;
+                case DOUBLE:
+                    writeDouble((double) serializableField.getRecordComponentValue(obj));
+                    break;
+                case FLOAT:
+                    writeFloat((float) serializableField.getRecordComponentValue(obj));
+                    break;
+            }
+        }
+        for (SerializableField serializableField : info.getFields()) {
+            if (serializableField.getKind() == Kind.OBJECT) {
+                doWriteObject(serializableField.getRecordComponentValue(obj), serializableField.isUnshared());
+            }
+        }
     }
 
     protected void doWriteFields(final SerializableClass info, final Object obj) throws IOException {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -54,6 +54,44 @@
 
     <profiles>
         <profile>
+            <id>jdk-less-than-16</id>
+            <activation>
+                <jdk>[1.8,16)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.7.0-jboss-1</version>
+                        <configuration>
+                            <testExcludes>
+                                <exclude>**/org/jboss/test/marshalling/RecordTests.java</exclude>
+                                <exclude>**/org/jboss/test/marshalling/RecordTestFactory.java</exclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk-greater-than-16</id>
+            <activation>
+                <jdk>[16,</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.7.0-jboss-1</version>
+                        <configuration>
+                            <testSource>16</testSource>
+                            <testTarget>16</testTarget>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>java8-test-profile</id>
             <activation>
                 <property>

--- a/tests/src/test/java/org/jboss/test/marshalling/RecordTestFactory.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/RecordTestFactory.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.test.marshalling;
+
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.Marshalling;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author rmartinc
+ */
+@Test(dataProvider = "recordProvider")
+public class RecordTestFactory {
+
+    @DataProvider (name = "recordProvider")
+    public static Object[][] parameters() {
+
+        Object[][] tests = new Object[6][3];
+
+        final MarshallingConfiguration config = new MarshallingConfiguration();
+        final MarshallerFactory riverMarshallerFactory = Marshalling.getProvidedMarshallerFactory("river");
+
+        tests[0][0] = new MarshallerFactoryTestMarshallerProvider(riverMarshallerFactory, 2);
+        tests[0][1] = new MarshallerFactoryTestUnmarshallerProvider(riverMarshallerFactory, 2);
+        tests[0][2] = config;
+
+        tests[1][0] = new MarshallerFactoryTestMarshallerProvider(riverMarshallerFactory, 3);
+        tests[1][1] = new MarshallerFactoryTestUnmarshallerProvider(riverMarshallerFactory, 3);
+        tests[1][2] = config;
+
+        tests[2][0] = new MarshallerFactoryTestMarshallerProvider(riverMarshallerFactory, 4);
+        tests[2][1] = new MarshallerFactoryTestUnmarshallerProvider(riverMarshallerFactory, 4);
+        tests[2][2] = config;
+
+        final MarshallerFactory serialMarshallerFactory = Marshalling.getProvidedMarshallerFactory("serial");
+        tests[3][0] = new MarshallerFactoryTestMarshallerProvider(serialMarshallerFactory);
+        tests[3][1] = new MarshallerFactoryTestUnmarshallerProvider(serialMarshallerFactory);
+        tests[3][2] = config;
+
+        tests[4][0] = new MarshallerFactoryTestMarshallerProvider(serialMarshallerFactory);
+        tests[4][1] = new ObjectInputStreamTestUnmarshallerProvider();
+        tests[4][2] = config;
+
+        tests[5][0] = new ObjectOutputStreamTestMarshallerProvider();
+        tests[5][1] = new MarshallerFactoryTestUnmarshallerProvider(serialMarshallerFactory);
+        tests[5][2] = config;
+
+        return tests;
+    }
+
+
+    @Factory(dataProvider = "recordProvider")
+    public Object[] getTests(TestMarshallerProvider testMarshallerProvider, TestUnmarshallerProvider testUnmarshallerProvider, MarshallingConfiguration configuration) {
+        return new Object[] {new RecordTests(testMarshallerProvider, testUnmarshallerProvider, configuration)};
+    }
+}

--- a/tests/src/test/java/org/jboss/test/marshalling/RecordTests.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/RecordTests.java
@@ -1,0 +1,352 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.test.marshalling;
+
+import java.io.NotSerializableException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.Unmarshaller;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class RecordTests extends TestBase {
+
+    public RecordTests(TestMarshallerProvider testMarshallerProvider, TestUnmarshallerProvider testUnmarshallerProvider, MarshallingConfiguration configuration) {
+        super(testMarshallerProvider, testUnmarshallerProvider, configuration);
+    }
+
+    public static record NonSerialized(int one, long two) {};
+
+    @Test(expectedExceptions = NotSerializableException.class)
+    public void testNonSerializable() throws Throwable {
+        NonSerialized ns = new NonSerialized(1, 2L);
+        ReadWriteTest readWriteTest = new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject(ns);
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+            }
+        };
+        runWriteOnly(readWriteTest);
+    }
+
+    public static record Empty() implements Serializable {};
+
+    @Test
+    public void testEmpty() throws Throwable {
+        Empty e1 = new Empty();
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject("Blah");
+                marshaller.writeObject(e1);
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+                AssertJUnit.assertEquals(e1, unmarshaller.readObject());
+            }
+        });
+    }
+
+    public static record Person(String firstname, String lastname, int age, boolean enabled) implements Serializable {};
+
+    @Test
+    public void testPerson() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = null;
+        Person p3 = new Person("jane", null, 35, false);
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject("Blah");
+                marshaller.writeObject(p1);
+                marshaller.writeObject(p2);
+                marshaller.writeObject(p3);
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+                AssertJUnit.assertEquals(p1, unmarshaller.readObject());
+                AssertJUnit.assertNull(unmarshaller.readObject());
+                AssertJUnit.assertEquals(p3, unmarshaller.readObject());
+            }
+        });
+    }
+
+    public static record Marriage(Person p1, Person p2, String address) implements Serializable {};
+
+    @Test
+    public void testMariage() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = new Person("Jane", "Doe", 35, false);
+        Marriage m = new Marriage(p1, p2, "22 Acacia Avenue");
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject("Blah");
+                marshaller.writeObject(m);
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+                AssertJUnit.assertEquals(m, unmarshaller.readObject());
+            }
+        });
+    }
+
+    @Test
+    public void testArray() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = new Person("Jane", "Doe", 35, false);
+        Person[] array = new Person[]{p1, p2, p1};
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject("Blah");
+                marshaller.writeObject(array);
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+                AssertJUnit.assertArrayEquals(array, (Person[]) unmarshaller.readObject());
+            }
+        });
+    }
+
+    @Test
+    public void testList() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = new Person("Jane", "Doe", 35, false);
+        Person p3 = new Person("Kate", "Doe", 2, true);
+        List<Person> list = new ArrayList<>();
+        list.add(p1);
+        list.add(p2);
+        list.add(p3);
+        list.add(p2);
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject("Blah");
+                marshaller.writeObject(list);
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+                AssertJUnit.assertEquals(list, (List<?>) unmarshaller.readObject());
+            }
+        });
+    }
+
+    public static class FullHouse implements Serializable {
+        private Marriage marriage;
+        private Person[] children;
+        private int rooms;
+        private String description;
+
+        public FullHouse(Marriage marriage) {
+            this.marriage = marriage;
+        }
+
+        public Marriage getMarriage() {
+            return marriage;
+        }
+
+        public void setMarriage(Marriage marriage) {
+            this.marriage = marriage;
+        }
+
+        public Person[] getChildren() {
+            return children;
+        }
+
+        public void setChildren(Person[] children) {
+            this.children = children;
+        }
+
+        public void addChild(Person c) {
+            if (children == null) {
+                children = new Person[1];
+                children[0] = c;
+            } else {
+                Person[] newChildren = Arrays.copyOf(children, children.length + 1);
+                newChildren[newChildren.length - 1] = c;
+                children = newChildren;
+            }
+        }
+
+        public int getRooms() {
+            return rooms;
+        }
+
+        public void setRooms(int rooms) {
+            this.rooms = rooms;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        @Override
+        public int hashCode() {
+            return 89 * (89 * 7 + Objects.hash(marriage, rooms, description))
+                    + Arrays.deepHashCode(this.children);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            final FullHouse other = (FullHouse) obj;
+            return this.rooms == other.rooms
+                    && Objects.equals(this.description, other.description)
+                    && Objects.equals(this.marriage, other.marriage)
+                    && Arrays.deepEquals(this.children, other.children);
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder().append(super.toString())
+                    .append(" marriage=").append(marriage)
+                    .append(" children=") .append(children == null? "null" : Arrays.asList(children))
+                    .append(" rooms=").append(rooms)
+                    .append(" description=").append(description)
+                    .toString();
+        }
+    }
+
+    @Test
+    public void testFullHouse() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = new Person("Jane", "Doe", 35, false);
+        Marriage m = new Marriage(p1, p2, "22 Acacia Avenue");
+        FullHouse h1 = new FullHouse(m);
+        h1.addChild(new Person("Jhon", "Doe Jr", 10, true));
+        h1.addChild(new Person("Janeth", "Doe", 8, true));
+        h1.setDescription("A happy house!!!");
+        h1.setRooms(5);
+        FullHouse h2 = new FullHouse(m);
+        h2.setRooms(3);
+
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject(h1);
+                marshaller.writeObject(h2);
+                marshaller.writeObject("Blah");
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals(h1, (FullHouse) unmarshaller.readObject());
+                AssertJUnit.assertEquals(h2, (FullHouse) unmarshaller.readObject());
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+            }
+        });
+    }
+
+    @Test
+    public void testFullHouseArray() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = new Person("Jane", "Doe", 35, false);
+        Marriage m = new Marriage(p1, p2, "22 Acacia Avenue");
+        FullHouse h1 = new FullHouse(m);
+        h1.addChild(new Person("Jhon", "Doe Jr", 10, true));
+        h1.addChild(new Person("Janeth", "Doe", 8, true));
+        h1.setDescription("A happy house!!!");
+        h1.setRooms(5);
+        FullHouse h2 = new FullHouse(m);
+        h2.setRooms(3);
+        FullHouse[] array = new FullHouse[]{h1, h2};
+
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject(h1);
+                marshaller.writeObject(array);
+                marshaller.writeObject("Blah");
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals(h1, (FullHouse) unmarshaller.readObject());
+                AssertJUnit.assertArrayEquals(array, (FullHouse[]) unmarshaller.readObject());
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+            }
+        });
+    }
+
+    @Test
+    public void testSet() throws Throwable {
+        Person p1 = new Person("John", "Doe", 31, true);
+        Person p2 = new Person("Jane", "Doe", 35, false);
+        Marriage m = new Marriage(p1, p2, "22 Acacia Avenue");
+        FullHouse h1 = new FullHouse(m);
+        h1.addChild(new Person("Jhon", "Doe Jr", 10, true));
+        h1.addChild(new Person("Janeth", "Doe", 8, true));
+        h1.setDescription("A happy house!!!");
+        h1.setRooms(5);
+        FullHouse h2 = new FullHouse(m);
+        h2.setRooms(3);
+        Set<FullHouse> set = new HashSet<>();
+        set.add(h1);
+        set.add(h2);
+        runReadWriteTest(new ReadWriteTest() {
+            @Override
+            public void runWrite(final Marshaller marshaller) throws Throwable {
+                marshaller.writeObject(h1);
+                marshaller.writeObject(set);
+                marshaller.writeObject("Blah");
+            }
+
+            @Override
+            public void runRead(final Unmarshaller unmarshaller) throws Throwable {
+                AssertJUnit.assertEquals(h1, (FullHouse) unmarshaller.readObject());
+                AssertJUnit.assertEquals(set, (Set<?>) unmarshaller.readObject());
+                AssertJUnit.assertEquals("Blah", unmarshaller.readObject());
+            }
+        });
+    }
+}

--- a/tests/src/test/java/org/jboss/test/marshalling/TestBase.java
+++ b/tests/src/test/java/org/jboss/test/marshalling/TestBase.java
@@ -92,7 +92,7 @@ public abstract class TestBase {
         this.configuration = configuration;
     }
 
-    public void runReadWriteTest(ReadWriteTest readWriteTest) throws Throwable {
+    public byte[] runWriteOnly(ReadWriteTest readWriteTest) throws Throwable {
         final MarshallingConfiguration readConfiguration = configuration.clone();
         readWriteTest.configureRead(readConfiguration);
 
@@ -104,8 +104,10 @@ public abstract class TestBase {
         System.out.println("Marshaller = " + marshaller + " (version set to " + readConfiguration.getVersion() + ")");
         readWriteTest.runWrite(marshaller);
         marshaller.finish();
-        final byte[] bytes = baos.toByteArray();
+        return baos.toByteArray();
+    }
 
+    public void runReadOnly(ReadWriteTest readWriteTest, byte[] bytes) throws Throwable {
         final MarshallingConfiguration writeConfiguration = configuration.clone();
         readWriteTest.configureWrite(writeConfiguration);
 
@@ -115,5 +117,10 @@ public abstract class TestBase {
         System.out.println("Unmarshaller = " + unmarshaller + " (version set to " + writeConfiguration.getVersion() + ")");
         readWriteTest.runRead(unmarshaller);
         unmarshaller.finish();
+    }
+
+    public void runReadWriteTest(ReadWriteTest readWriteTest) throws Throwable {
+        byte[] bytes = runWriteOnly(readWriteTest);
+        runReadOnly(readWriteTest, bytes);
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBMAR-241

Adding record serialization/deserialization to the implementations. Main changes:

* I have used versioning to add java-16, so now api needs jdk-16 as the minimum jdk version (the first version that uses records without the preview condition). If you prefer to not have this requirement, using a full reflection solution and maintaining jdk-9 minimum, just let me know.

* The main pom reduced minimum version from 9 to 8. This was done because testing previous versions is easier this way, you can just compile everything with 17 (for example) and then only the test folder can be executed with java 11 or 1.8 directly (record tests are just not compiled/executed).

```bash
export JAVA_HOME=/path/to/jdk-17
mvn clean install
cd tests
export JAVA_HOME=/path/to/jdk-1.8.0
mvn clean test
```

* Changes done in api, river and serial (un)marshallers to include records.
* New test and factory classes to check the records marshalling and unmarshalling. If you think more tests are needed just let me know too.

@ropalka I think the PR is ready for review.

Thanks!