### PR TITLE
[JBMAR-248] Require JDK17 for building but by default compile to JDK11 except records support that targets JDK16

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,10 +33,6 @@
         <version>2.2.0.Final-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <jdk.min.version>16</jdk.min.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.modules</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <jdk.min.version>1.8</jdk.min.version>
+        <jdk.min.version>17</jdk.min.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBMAR-248