### PR TITLE
[JBMAR-260] Use Class.getName() instead of Class.getSimpleName() for detecting hidden classes

### DIFF
--- a/api/src/main/java/org/jboss/marshalling/reflect/SerializableClass.java
+++ b/api/src/main/java/org/jboss/marshalling/reflect/SerializableClass.java
@@ -91,7 +91,7 @@ public final class SerializableClass {
         serMethods = new SerMethods(subject);
         final ObjectStreamClass objectStreamClass = ObjectStreamClass.lookup(subject);
         effectiveSerialVersionUID = objectStreamClass == null ? 0L : objectStreamClass.getSerialVersionUID(); // todo find a better solution
-        if (subject.getSimpleName().indexOf('/') != -1) {
+        if (subject.getName().indexOf('/') != -1) {
             // it's a hidden class
             fields = NOFIELDS;
             this.fieldsByName = Collections.emptyMap();


### PR DESCRIPTION
https://issues.redhat.com/browse/JBMAR-260

Upstream PR: https://github.com/jboss-remoting/jboss-marshalling/pull/158