### PR TITLE
Getting more information when a StackOverflowError occurs

### DIFF
--- a/api/src/main/java/org/jboss/marshalling/TraceInformation.java
+++ b/api/src/main/java/org/jboss/marshalling/TraceInformation.java
@@ -18,6 +18,7 @@
 
 package org.jboss.marshalling;
 
+import java.util.Arrays;
 import org.jboss.marshalling.reflect.SerializableClass;
 import org.jboss.marshalling.reflect.SerializableField;
 
@@ -59,17 +60,15 @@ public final class TraceInformation extends Throwable {
         if (t == null) {
             throw new NullPointerException("t is null");
         }
-        Throwable c;
-        while (! (t instanceof TraceInformation)) {
-            c = t.getCause();
-            if (c == null) try {
-                t.initCause(c = new TraceInformation());
-            } catch (RuntimeException e) {
-                // ignored
-            }
-            t = c;
+        var optionalTi = Arrays.stream(t.getSuppressed()).filter(TraceInformation.class::isInstance).map(TraceInformation.class::cast).findFirst();
+        TraceInformation ti;
+        if (optionalTi.isEmpty()) {
+            ti = new TraceInformation();
+            t.addSuppressed(ti);
+        } else {
+            ti = optionalTi.get();
         }
-        return (TraceInformation) t;
+        return ti;
     }
 
     private static String getNiceClassName(Class<?> clazz) {

--- a/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
+++ b/river/src/main/java/org/jboss/marshalling/river/RiverUnmarshaller.java
@@ -207,6 +207,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
         } catch (RuntimeException e) {
             TraceInformation.addIncompleteObjectInformation(e, enclosingClassName);
             throw e;
+        } catch (StackOverflowError e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -222,6 +224,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
         } catch (RuntimeException e) {
             TraceInformation.addIndexInformation(e, idx, size, TraceInformation.IndexType.ELEMENT);
             throw e;
+        } catch (StackOverflowError e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -237,6 +241,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
         } catch (RuntimeException e) {
             TraceInformation.addIndexInformation(e, idx, size, key ? TraceInformation.IndexType.MAP_KEY : TraceInformation.IndexType.MAP_VALUE);
             throw e;
+        } catch (StackOverflowError e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -1620,6 +1626,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
             TraceInformation.addIncompleteObjectInformation(e, descriptor.getType());
             exceptionListener.handleUnmarshallingException(e, descriptor.getType());
             throw e;
+        } catch (StackOverflowError e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -1988,6 +1996,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
                 TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
                 TraceInformation.addObjectInformation(e, obj);
                 throw e;
+            } catch (StackOverflowError e) {
+                throw new RuntimeException(e);
             }
         }
     }
@@ -2042,6 +2052,8 @@ public class RiverUnmarshaller extends AbstractUnmarshaller {
             } catch (RuntimeException e) {
                 TraceInformation.addFieldInformation(e, descriptor.getSerializableClass(), serializableField);
                 throw e;
+            } catch (StackOverflowError e) {
+                throw new RuntimeException(e);
             }
         }
     }


### PR DESCRIPTION
Hello 👋 ,

I work on the Jenkins project, and I'm investigating issues we're seeing while using this library to marshal and unmarshal a pipeline runtime state.

When marshalling or unmarshalling a very deep object structure, this can raise `StackOverflowError` depending on the configured JVM stack size.

Unfortunately, the current implementation only catches various exceptions, not `StackOverflowError`. In addition, when catching these the existing mecanism to attach `TraceInformation` doesn't work.

* `StackOverflowError` doesn't support adding a cause (the current mechanism used by TraceInformation)
* Adding `TraceInformation` as suppressed exception can itself lead to a new `StackOverflowError`.

These experimental changes do 2 things:
* Use suppressed exceptions instead of cause to attach `TraceInformation`. 
* Wrap `StackOverflowError` into a `RuntimeException`. That way, the `TraceInformation` object can be attached as soon as the catching code goes up one level.

I don't expect this to be merged at all, it is more of a way to open discussion.

While looking at the project, I was also a bit confused:
* The [readme](https://github.com/jboss-remoting/jboss-marshalling/blob/main/README.md?plain=1#L21-L23) states issues should be reported using GH issues, however they are disabled for this repository.
* The [contributing](https://github.com/jboss-remoting/jboss-marshalling/blob/main/CONTRIBUTING.md?plain=1#L119-L123) document states issues are managed using RedHat Jira.
So which is it?